### PR TITLE
Fix issue with cursor positioning in shell during recordings

### DIFF
--- a/recorder.js
+++ b/recorder.js
@@ -51,6 +51,14 @@ class Recorder {
       // Inject a terminal variable to let the child processes know
       // of the active recording so they we don't record recursively
       env: { ...process.env, DASHCAM_TERMINAL_RECORDING: "TRUE" },
+      cols: process.stdout.columns,
+      rows: process.stdout.rows,
+      cwd: process.cwd(),
+    });
+
+    process.stdout.on("resize", () => {
+      this.#ptyProcess.cols = process.stdout.columns;
+      this.#ptyProcess.rows = process.stdout.rows;
     });
 
     process.stdin.on("data", this.#onInput.bind(this));


### PR DESCRIPTION
I first was under the assumption that the issue was caused by out of order callback/async operations.
But in the end it turned out to be easier than i thought, we just need to set the cols and rows of our spawned pty process and update them as the terminal size changes.

This seems to have fixed all cursor issues for me on windows/git bash.
@ianjennings Could you try this on macos and see if it fixed on there as well?