### PR TITLE
Update to Node v22.19.0 LTS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashcam",
-  "version": "0.8.0",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashcam",
-      "version": "0.8.0",
+      "version": "0.8.2",
       "license": "ISC",
       "dependencies": {
         "@homebridge/node-pty-prebuilt-multiarch": "^0.12.0",
@@ -22,6 +22,9 @@
       },
       "devDependencies": {
         "husky": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@homebridge/node-pty-prebuilt-multiarch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,9 +123,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1064,9 +1064,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
-      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
   "devDependencies": {
     "husky": "^7.0.0"
   },
+  "engines": {
+    "node": ">=22.19.0"
+  },
   "volta": {
-    "node": "16.20.2"
+    "node": "22.19.0"
   }
 }


### PR DESCRIPTION
This speeds up installs considerably and also addresses a few `npm` security alerts:
> https://github.com/replayableio/cli/security/dependabot/4